### PR TITLE
Include the repository field

### DIFF
--- a/goldboot-macros/Cargo.toml
+++ b/goldboot-macros/Cargo.toml
@@ -6,6 +6,7 @@ license = "AGPL-3.0-only"
 name = "goldboot-macros"
 rust-version = "1.74"
 version = "0.0.1"
+repository = "https://github.com/fossable/goldboot"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.